### PR TITLE
Ammowarnings

### DIFF
--- a/qcsrc/client/Main.qc
+++ b/qcsrc/client/Main.qc
@@ -115,6 +115,18 @@ void CSQC_Init(void)
     registercvar("cl_effects_lightningarc_count", "1", CVAR_SAVE);
     registercvar("g_waypointsprite_pointer_scale", "1", CVAR_SAVE);
     registercvar("g_waypointsprite_pointer_edgefadescale", "1", CVAR_SAVE);
+	registercvar("cl_lowammowarnings", "1", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_bullets", "20", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_cells", "15", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_rockets", "10", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_shells", "10", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_cells", "10", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_zapper_heat", "25", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_campingrifle_bulletsremaining", "2", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_width", "20", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_height", "20", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_position", "30", CVAR_SAVE);
+	
     gametype = 0;
 
 	// sbar_fields uses strunzone on the titles!

--- a/qcsrc/client/Main.qc
+++ b/qcsrc/client/Main.qc
@@ -123,8 +123,7 @@ void CSQC_Init(void)
 	registercvar("cl_lowammowarnings_cells", "10", CVAR_SAVE);
 	registercvar("cl_lowammowarnings_zapper_heat", "25", CVAR_SAVE);
 	registercvar("cl_lowammowarnings_campingrifle_bulletsremaining", "2", CVAR_SAVE);
-	registercvar("cl_lowammowarnings_width", "20", CVAR_SAVE);
-	registercvar("cl_lowammowarnings_height", "20", CVAR_SAVE);
+	registercvar("cl_lowammowarnings_size", "20", CVAR_SAVE);
 	registercvar("cl_lowammowarnings_position", "30", CVAR_SAVE);
 	
     gametype = 0;

--- a/qcsrc/client/View.qc
+++ b/qcsrc/client/View.qc
@@ -688,6 +688,8 @@ void CSQC_UpdateView(float w, float h)
 			Sbar_ShowSpeed();
 		if (cvar("cl_showacceleration"))
 			Sbar_ShowAcceleration();
+		if (cvar("cl_lowammowarnings"))
+			Sbar_ShowLowammo();
 		
  		Sbar_DrawCenterPrint(); // draw centerprint messages even if viewsize >= 120
 	}

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2887,19 +2887,19 @@ void Sbar_ShowLowammo(){
 	float currammo;
 	float currammotype;
 	float ammocode;
-	float bulletthreshold = cvar("cl_lowammowarnings_campingrifle_bulletsremaining") ? cvar("cl_lowammowarnings_campingrifle_bulletsremaining") : 2;
+	float bulletthreshold = cvar("cl_lowammowarnings_campingrifle_bulletsremaining");
 	float bulletwarn = cvar("cl_lowammowarnings_bullets") ? cvar("cl_lowammowarnings_bullets") : 20;
 	float cellwarn = cvar("cl_lowammowarnings_cells") ? cvar("cl_lowammowarnings_cells") : 15;
 	float rocketwarn = cvar("cl_lowammowarnings_rockets") ? cvar("cl_lowammowarnings_rockets") : 10;
 	float shellwarn = cvar("cl_lowammowarnings_shells") ? cvar("cl_lowammowarnings_shells") : 10;
-	pos_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : vid_conheight / 9;
 	scale_x = cvar("cl_lowammowarnings_width") ? cvar("cl_lowammowarnings_width") : 20;
 	scale_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : 20;
+	pos_y = cvar("cl_lowammowarnings_position") ? cvar("cl_lowammowarnings_position") : 20;
 	
 	//low ammo warning if either unlimited ammo and low on rifle clip size or limited ammo and low on ammo pool amount
 	if((currweapon == WEP_CAMPINGRIFLE) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
 		float currbullets = getstati(STAT_BULLETS_LOADED);
-		if(cvar("cl_lowammowarnings_campingrifle_bulletsremaining") >= 0){ //allow disabling warnings for the rifle if the cvar is < 1 
+		if(cvar("cl_lowammowarnings_campingrifle_bulletsremaining")){
 			bulletthreshold = bound(0, bulletthreshold, getstati(STAT_BULLETS_MAX));
 			if(currbullets <= bulletthreshold){
 				showwarning = 1;

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2928,8 +2928,8 @@ void Sbar_ShowLowammo(){
 	float currammo, currammotype, ammocode;
 	float clipheatwarn = GetSpecialCaseWarn(currweapon);
 	float warn = GetLowAmmoCvar(currweapon);
-	scale_x = cvar("cl_lowammowarnings_width");
-	scale_y = cvar("cl_lowammowarnings_height");
+	scale_x = cvar("cl_lowammowarnings_size");
+	scale_y = cvar("cl_lowammowarnings_size");
 	pos_y = cvar("cl_lowammowarnings_position");
 	
 	//carrying either camping rifle or zapper
@@ -2958,6 +2958,7 @@ void Sbar_ShowLowammo(){
 			showwarning = 1;
 		}
 	}
+	drawfont = sbar_bigfont;
 	if(showwarning){
 		string ammoname = GetFriendlyAmmoName(currammotype);
 		drawstringcenter(pos, strcat("Low ", ammoname, "!"), scale, '1 1 1', 1, DRAWFLAG_NORMAL);
@@ -2965,9 +2966,10 @@ void Sbar_ShowLowammo(){
 	if(showspecialwarning){
 		string weaponname = get_weaponinfo(currweapon).message;
 		string specialwarn = GetSpecialCaseWarnString(currweapon);
-		pos_y = pos_y - 20;
+		pos_y = pos_y - scale_y;
 		drawstringcenter(pos, strcat(weaponname, " ", specialwarn, "!"), scale, '1 1 1', 1, DRAWFLAG_NORMAL);
 	}
+	drawfont = sbar_font;
 }
 
 void Sbar_Reset (void)

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2887,21 +2887,23 @@ void Sbar_ShowLowammo(){
 	float currammo;
 	float currammotype;
 	float ammocode;
-	float magazineratio = cvar("cl_lowammowarnings_magazineratio") ? cvar("cl_lowammowarnings_magazineratio") : 0.25; //ratio of bullets left
+	float bulletthreshold = cvar("cl_lowammowarnings_campingrifle_bulletsremaining") ? cvar("cl_lowammowarnings_campingrifle_bulletsremaining") : 2;
 	float bulletwarn = cvar("cl_lowammowarnings_bullets") ? cvar("cl_lowammowarnings_bullets") : 20;
 	float cellwarn = cvar("cl_lowammowarnings_cells") ? cvar("cl_lowammowarnings_cells") : 15;
 	float rocketwarn = cvar("cl_lowammowarnings_rockets") ? cvar("cl_lowammowarnings_rockets") : 10;
 	float shellwarn = cvar("cl_lowammowarnings_shells") ? cvar("cl_lowammowarnings_shells") : 10;
-	pos_y = vid_conheight / 9;
-	scale_x = cvar("cl_lowammowarnings_scalex");
-	scale_y = cvar("cl_lowammowarnings_scaley");
+	pos_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : vid_conheight / 9;
+	scale_x = cvar("cl_lowammowarnings_width") ? cvar("cl_lowammowarnings_width") : 20;
+	scale_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : 20;
 	
 	//low ammo warning if either unlimited ammo and low on rifle clip size or limited ammo and low on ammo pool amount
 	if((currweapon == WEP_CAMPINGRIFLE) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
-		float currratio = getstati(STAT_BULLETS_LOADED) / getstati(STAT_BULLETS_MAX);
-		magazineratio = bound(0, magazineratio, 1);
-		if(currratio <= magazineratio){
-			showwarning = 1;
+		float currbullets = getstati(STAT_BULLETS_LOADED);
+		if(cvar("cl_lowammowarnings_campingrifle_bulletsremaining") >= 0){ //allow disabling warnings for the rifle if the cvar is < 1 
+			bulletthreshold = bound(0, bulletthreshold, getstati(STAT_BULLETS_MAX));
+			if(currbullets <= bulletthreshold){
+				showwarning = 1;
+			}
 		}
 	}
 	else{

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2892,6 +2892,7 @@ void Sbar_ShowLowammo(){
 	float cellwarn = cvar("cl_lowammowarnings_cells") ? cvar("cl_lowammowarnings_cells") : 15;
 	float rocketwarn = cvar("cl_lowammowarnings_rockets") ? cvar("cl_lowammowarnings_rockets") : 10;
 	float shellwarn = cvar("cl_lowammowarnings_shells") ? cvar("cl_lowammowarnings_shells") : 10;
+	float heatwarn = cvar("cl_lowammowarnings_zapper_heat") ? cvar("cl_lowammowarnings_zapper_heat") : 25;
 	scale_x = cvar("cl_lowammowarnings_width") ? cvar("cl_lowammowarnings_width") : 20;
 	scale_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : 20;
 	pos_y = cvar("cl_lowammowarnings_position") ? cvar("cl_lowammowarnings_position") : 20;
@@ -2902,6 +2903,15 @@ void Sbar_ShowLowammo(){
 		if(cvar("cl_lowammowarnings_campingrifle_bulletsremaining")){
 			bulletthreshold = bound(0, bulletthreshold, getstati(STAT_BULLETS_MAX));
 			if(currbullets <= bulletthreshold){
+				showwarning = 1;
+			}
+		}
+	}
+	else if((currweapon == WEP_ZAPPER) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
+		float currheat = getstatf(STAT_ZAPPER_HEAT);
+		currheat = floor((1 - currheat) * 100);
+		if(cvar("cl_lowammowarnings_zapper_heat")){
+			if(currheat <= heatwarn){
 				showwarning = 1;
 			}
 		}

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2854,6 +2854,19 @@ float GetAmmoItemCode(float i)
 	}
 }
 
+float GetAmmoStatFromCode(float i)
+{
+	switch(i){
+		case IT_SHELLS: return STAT_SHELLS;
+		case IT_NAILS: return STAT_NAILS;
+		case IT_ROCKETS: return STAT_ROCKETS;
+		case IT_CELLS: return STAT_CELLS;
+		case IT_FUEL: return STAT_FUEL;
+		default: return -1;
+	
+	}
+}
+
 string GetAmmoPicture(float i)
 {
 	switch(i)
@@ -2864,6 +2877,63 @@ string GetAmmoPicture(float i)
 		case 3: return "gfx/hud/sb_cells";
 		case 4: return "gfx/hud/sb_fuel";
 		default: return "";
+	}
+}
+
+void Sbar_ShowLowammo(){
+	vector pos, scale;
+	float currweapon = getstati(STAT_SWITCHWEAPON);
+	float showwarning = 0;
+	float currammo;
+	float currammotype;
+	float ammocode;
+	float magazineratio = cvar("cl_lowammowarnings_magazineratio") ? cvar("cl_lowammowarnings_magazineratio") : 0.25; //ratio of bullets left
+	float bulletwarn = cvar("cl_lowammowarnings_bullets") ? cvar("cl_lowammowarnings_bullets") : 20;
+	float cellwarn = cvar("cl_lowammowarnings_cells") ? cvar("cl_lowammowarnings_cells") : 15;
+	float rocketwarn = cvar("cl_lowammowarnings_rockets") ? cvar("cl_lowammowarnings_rockets") : 10;
+	float shellwarn = cvar("cl_lowammowarnings_shells") ? cvar("cl_lowammowarnings_shells") : 10;
+	pos_y = vid_conheight / 9;
+	scale_x = cvar("cl_lowammowarnings_scalex");
+	scale_y = cvar("cl_lowammowarnings_scaley");
+	
+	//low ammo warning if either unlimited ammo and low on rifle clip size or limited ammo and low on ammo pool amount
+	if((currweapon == WEP_CAMPINGRIFLE) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
+		float currratio = getstati(STAT_BULLETS_LOADED) / getstati(STAT_BULLETS_MAX);
+		magazineratio = bound(0, magazineratio, 1);
+		if(currratio <= magazineratio){
+			showwarning = 1;
+		}
+	}
+	else{
+		currammotype = get_weaponinfo(currweapon).items;
+		ammocode = GetAmmoStatFromCode(currammotype);
+		if(ammocode > 0) //prevent sending <0 to getstati
+			currammo = getstati(GetAmmoStatFromCode(currammotype));
+		
+		switch(currammotype){
+			case IT_SHELLS:
+			if(currammo <= shellwarn)
+				showwarning = 1;
+			break;
+			case IT_NAILS:
+			if(currammo <= bulletwarn)
+				showwarning = 1;
+			break;
+			case IT_ROCKETS:
+			if(currammo <= rocketwarn)
+				showwarning = 1;
+			break;
+			case IT_CELLS:
+			if(currammo <= cellwarn)
+				showwarning = 1;
+			break;
+			default:
+				showwarning = 0;
+			break;
+		}
+	}
+	if(showwarning){
+		drawstringcenter(pos, "Low ammo warning!", scale, '1 1 1', 1, DRAWFLAG_NORMAL);
 	}
 }
 

--- a/qcsrc/client/sbar.qc
+++ b/qcsrc/client/sbar.qc
@@ -2867,6 +2867,18 @@ float GetAmmoStatFromCode(float i)
 	}
 }
 
+string GetFriendlyAmmoName(float i){
+	switch(i){
+		case IT_SHELLS: return "shells";
+		case IT_NAILS: return "bullets";
+		case IT_ROCKETS: return "rockets";
+		case IT_CELLS: return "cells";
+		case IT_FUEL: return "fuel";
+		default: return "";
+	}
+
+}
+
 string GetAmmoPicture(float i)
 {
 	switch(i)
@@ -2880,72 +2892,81 @@ string GetAmmoPicture(float i)
 	}
 }
 
+float GetLowAmmoCvar(float currweapon){
+	float currammotype = get_weaponinfo(currweapon).items;
+	switch(currammotype){
+		case IT_SHELLS: return cvar("cl_lowammowarnings_shells");
+		case IT_NAILS: return cvar("cl_lowammowarnings_bullets");
+		case IT_ROCKETS: return cvar("cl_lowammowarnings_rockets");
+		case IT_CELLS: return cvar("cl_lowammowarnings_cells");
+		default: return 0;
+	}
+}
+
+float GetSpecialCaseWarn(float currweapon){
+	//return any unique ammo system warning such as camping rifle clip or zapper heat
+	switch(currweapon){
+		case WEP_CAMPINGRIFLE: return cvar("cl_lowammowarnings_campingrifle_bulletsremaining");
+		case WEP_ZAPPER: return cvar("cl_lowammowarnings_zapper_heat");
+		default: return 0;
+	}
+}
+
+string GetSpecialCaseWarnString(float currweapon){
+	switch(currweapon){
+		case WEP_CAMPINGRIFLE: return "magazine low";
+		case WEP_ZAPPER: return "heat high";
+		default: return "";
+	}
+}
+
 void Sbar_ShowLowammo(){
 	vector pos, scale;
 	float currweapon = getstati(STAT_SWITCHWEAPON);
 	float showwarning = 0;
-	float currammo;
-	float currammotype;
-	float ammocode;
-	float bulletthreshold = cvar("cl_lowammowarnings_campingrifle_bulletsremaining");
-	float bulletwarn = cvar("cl_lowammowarnings_bullets") ? cvar("cl_lowammowarnings_bullets") : 20;
-	float cellwarn = cvar("cl_lowammowarnings_cells") ? cvar("cl_lowammowarnings_cells") : 15;
-	float rocketwarn = cvar("cl_lowammowarnings_rockets") ? cvar("cl_lowammowarnings_rockets") : 10;
-	float shellwarn = cvar("cl_lowammowarnings_shells") ? cvar("cl_lowammowarnings_shells") : 10;
-	float heatwarn = cvar("cl_lowammowarnings_zapper_heat") ? cvar("cl_lowammowarnings_zapper_heat") : 25;
-	scale_x = cvar("cl_lowammowarnings_width") ? cvar("cl_lowammowarnings_width") : 20;
-	scale_y = cvar("cl_lowammowarnings_height") ? cvar("cl_lowammowarnings_height") : 20;
-	pos_y = cvar("cl_lowammowarnings_position") ? cvar("cl_lowammowarnings_position") : 20;
+	float showspecialwarning = 0;
+	float currammo, currammotype, ammocode;
+	float clipheatwarn = GetSpecialCaseWarn(currweapon);
+	float warn = GetLowAmmoCvar(currweapon);
+	scale_x = cvar("cl_lowammowarnings_width");
+	scale_y = cvar("cl_lowammowarnings_height");
+	pos_y = cvar("cl_lowammowarnings_position");
 	
-	//low ammo warning if either unlimited ammo and low on rifle clip size or limited ammo and low on ammo pool amount
-	if((currweapon == WEP_CAMPINGRIFLE) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
-		float currbullets = getstati(STAT_BULLETS_LOADED);
-		if(cvar("cl_lowammowarnings_campingrifle_bulletsremaining")){
-			bulletthreshold = bound(0, bulletthreshold, getstati(STAT_BULLETS_MAX));
-			if(currbullets <= bulletthreshold){
-				showwarning = 1;
+	//carrying either camping rifle or zapper
+	if(clipheatwarn){
+		if(currweapon == WEP_CAMPINGRIFLE){
+			float currbullets = getstati(STAT_BULLETS_LOADED);
+			if(currbullets <= clipheatwarn){
+				showspecialwarning = 1;
+			}
+		}
+		else if(currweapon == WEP_ZAPPER){
+			float currheat = getstatf(STAT_ZAPPER_HEAT);
+			currheat = floor((1 - currheat) * 100);
+			if(currheat <= clipheatwarn){
+				showspecialwarning = 1;
 			}
 		}
 	}
-	else if((currweapon == WEP_ZAPPER) && (getstati(STAT_ITEMS) & IT_UNLIMITED_AMMO)){
-		float currheat = getstatf(STAT_ZAPPER_HEAT);
-		currheat = floor((1 - currheat) * 100);
-		if(cvar("cl_lowammowarnings_zapper_heat")){
-			if(currheat <= heatwarn){
-				showwarning = 1;
-			}
-		}
-	}
-	else{
+	if(warn){
 		currammotype = get_weaponinfo(currweapon).items;
 		ammocode = GetAmmoStatFromCode(currammotype);
 		if(ammocode > 0) //prevent sending <0 to getstati
 			currammo = getstati(GetAmmoStatFromCode(currammotype));
 		
-		switch(currammotype){
-			case IT_SHELLS:
-			if(currammo <= shellwarn)
-				showwarning = 1;
-			break;
-			case IT_NAILS:
-			if(currammo <= bulletwarn)
-				showwarning = 1;
-			break;
-			case IT_ROCKETS:
-			if(currammo <= rocketwarn)
-				showwarning = 1;
-			break;
-			case IT_CELLS:
-			if(currammo <= cellwarn)
-				showwarning = 1;
-			break;
-			default:
-				showwarning = 0;
-			break;
+		if(currammo <= warn){
+			showwarning = 1;
 		}
 	}
 	if(showwarning){
-		drawstringcenter(pos, "Low ammo warning!", scale, '1 1 1', 1, DRAWFLAG_NORMAL);
+		string ammoname = GetFriendlyAmmoName(currammotype);
+		drawstringcenter(pos, strcat("Low ", ammoname, "!"), scale, '1 1 1', 1, DRAWFLAG_NORMAL);
+	}
+	if(showspecialwarning){
+		string weaponname = get_weaponinfo(currweapon).message;
+		string specialwarn = GetSpecialCaseWarnString(currweapon);
+		pos_y = pos_y - 20;
+		drawstringcenter(pos, strcat(weaponname, " ", specialwarn, "!"), scale, '1 1 1', 1, DRAWFLAG_NORMAL);
 	}
 }
 


### PR DESCRIPTION
This allows users to be warned textually if they are currently low on ammo. This works for the campingrifle magazine (if ammo is unlimited), zapper heat and ammo pool on a per ammo type basis. The treshold for the camping rifle clip, zapper heat or currently held ammo to trigger the warning can be configured, as well as the veritical position and size of the warning.