### PR TITLE
FastAW config changes (WIP)

### DIFF
--- a/modfiles/rm-custom/fastaw.cfg
+++ b/modfiles/rm-custom/fastaw.cfg
@@ -17,3 +17,4 @@ exec rm-custom/fastaw/powerups.cfg
 exec rm-custom/fastaw/rm.cfg
 exec rm-custom/fastaw/hook.cfg
 exec rm-custom/fastaw/healtharmor.cfg
+exec rm-custom/fastaw/buffs.cfg

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -45,3 +45,8 @@ g_buffs_supply_grant_ammo 40
 
 // Haste
 g_buffs_haste_refire_rate 0.85
+
+// Ignite
+g_buffs_ignite_damage_fire 0.2
+g_buffs_ignite_burntime 4
+g_buffs_ignite_stack 1

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -21,8 +21,8 @@ g_buffs_medic_selfhealfactor 0.25 // 0.5
 g_buffs_medic_headshot 1
 g_buffs_medic_revivefactor 1.3
 g_buffs_medic_pauserot 1
-g_buffs_medic_armor 50
-g_buffs_medic_armor_regen 0.5
+g_buffs_medic_armor 0
+g_buffs_medic_armor_regen 0
 g_buffs_medic_forcefactor_self 1
 g_buffs_medic_forcefactor_team 1
 

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -7,9 +7,9 @@ g_buffs_replace 2
 
 // Guard
 g_buffs_guard_health 100
-g_buffs_guard_armor 150
+g_buffs_guard_armor 100
 g_buffs_guard_health_regen 0.15 // 0.2
-g_buffs_guard_armor_regen 0.11 // 0.2
+g_buffs_guard_armor_regen 0.15 // 0.2
 g_buffs_guard_pickup_health 100
 g_buffs_guard_pickup_armor 100
 

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -42,3 +42,6 @@ g_buffs_tenacity_takedamage_self 0.25 // 0
 
 // Supply
 g_buffs_supply_grant_ammo 40
+
+// Haste
+g_buffs_haste_refire_rate 0.85

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -1,0 +1,44 @@
+
+g_buffs 1
+g_buffs_randomize 2
+g_buffs_randomize_dual 0.1
+g_buffs_random_spawns 1
+g_buffs_replace 2
+
+// Guard
+g_buffs_guard_health 100
+g_buffs_guard_armor 150
+g_buffs_guard_health_regen 0.15 // 0.2
+g_buffs_guard_armor_regen 0.11 // 0.2
+g_buffs_guard_pickup_health 100
+g_buffs_guard_pickup_armor 100
+
+// Medic
+g_buffs_medic_maxhealth 200
+g_buffs_medic_damagefactor 0.3
+g_buffs_medic_healfactor 1.2
+g_buffs_medic_selfhealfactor 0.25 // 0.5
+g_buffs_medic_headshot 1
+g_buffs_medic_revivefactor 1.3
+g_buffs_medic_pauserot 1
+g_buffs_medic_armor 50
+g_buffs_medic_armor_regen 0.5
+g_buffs_medic_forcefactor_self 1
+g_buffs_medic_forcefactor_team 1
+
+// Vampire
+g_buffs_vampire 1
+g_buffs_vampire_baseline 0
+g_buffs_vampire_factor 0.65 // 0.75
+g_buffs_vampire_time 7 // 7
+g_buffs_vampire_pauserot 0
+
+// Tenacity
+g_buffs_tenacity 1
+g_buffs_tenacity_baseline 0
+g_buffs_tenacity_takedamage 0.75 // 0.9
+g_buffs_tenacity_takedamage_aoe 0.75 // 0
+g_buffs_tenacity_takedamage_self 0.25 // 0
+
+// Supply
+g_buffs_supply_grant_ammo 40

--- a/modfiles/rm-custom/fastaw/buffs.cfg
+++ b/modfiles/rm-custom/fastaw/buffs.cfg
@@ -30,8 +30,9 @@ g_buffs_medic_forcefactor_team 1
 g_buffs_vampire 1
 g_buffs_vampire_baseline 0
 g_buffs_vampire_factor 0.65 // 0.75
-g_buffs_vampire_time 7 // 7
-g_buffs_vampire_pauserot 0
+g_buffs_vampire_time 5 // 7
+g_buffs_vampire_pauserot 0.5
+g_buffs_vampire_limit 150
 
 // Tenacity
 g_buffs_tenacity 1

--- a/modfiles/rm-custom/fastaw/healtharmor.cfg
+++ b/modfiles/rm-custom/fastaw/healtharmor.cfg
@@ -34,39 +34,3 @@ g_pickup_healthmega 100
 g_pickup_healthmega_max 200
 g_pickup_healthsmall 5
 g_pickup_healthsmall_max 200
-
-// Guard
-g_buffs_guard_health 100 "Regenerate health at least up to this value"
-g_buffs_guard_armor 150 "Regenerate armor at least up to this value"
-g_buffs_guard_health_regen 0.15 "Minimum health regeneration rate" //0.2
-g_buffs_guard_armor_regen 0.11 "Minimum health regeneration rate" //0.2
-g_buffs_guard_pickup_health 100 "Give up to this much health on pickup"
-g_buffs_guard_pickup_armor 100 "Give up to this much armor on pickup"
-
-// Medic
-g_buffs_medic_maxhealth 200 "Limit beyond which friendly targets cannot be healed"
-g_buffs_medic_damagefactor 0.4 "Damage multiplier for medics"
-g_buffs_medic_healfactor 1.2 "Healing multiplier for medics"
-g_buffs_medic_selfhealfactor 0.25 "Self-healing multiplier for medics (stacks with g_buffs_medic_healfactor multiplicatively)" //0.5
-g_buffs_medic_headshot 1 "Allows medic healing to benefit from headshot bonuses"
-g_buffs_medic_revivefactor 1.3 "Revival speed multiplier for medics"
-g_buffs_medic_pauserot 1 "For how long to pause health rot after healing"
-g_buffs_medic_armor 50 "Regenerate armor up to at least this much for medics"
-g_buffs_medic_armor_regen 0.5 "Armor regeneration rate for medics"
-g_buffs_medic_forcefactor_self 1
-g_buffs_medic_forcefactor_team 1
-
-// Vampire
-seta g_buffs_vampire 1 "Enable the Vampire Buff"
-seta g_buffs_vampire_baseline 0 "If >0, apply the effects of the buff to every player by default (can be used even if the buff is disabled, value controls buff power)"
-seta g_buffs_vampire_factor 0.65 "Damage->Healing multiplier" // 0.75
-seta g_buffs_vampire_time 7 "Time over which healing is applied. If 0, full amount is restored instantly" // 7
-seta g_buffs_vampire_pauserot 0 "Pause health rot for this much seconds after a heal tick"
-
-// Tenacity
-seta g_buffs_tenacity 1 "Enable the Tenacity Buff"
-seta g_buffs_tenacity_baseline 0 "If >0, apply the effects of the buff to every player by default (can be used even if the buff is disabled, value controls buff power)"
-seta g_buffs_tenacity_takedamage 0.75 "Damage taken multiplier" // 0.9
-seta g_buffs_tenacity_takedamage_aoe 0.75 "Damage taken multiplier for AOE damage and Nadget damage" // 0
-seta g_buffs_tenacity_takedamage_self 0.25 "Damage taken multiplier for self damage" // 0
-

--- a/modfiles/rm-custom/fastaw/rm.cfg
+++ b/modfiles/rm-custom/fastaw/rm.cfg
@@ -4,12 +4,7 @@ g_terminals 1
 g_spawnclosetoteam 0
 g_freezetag_soulmates 0
 
-g_buffs 1
-g_buffs_randomize 2
-g_buffs_randomize_dual 0.1
-g_buffs_random_spawns 1
 g_clanarena_buffs_team_only 0
-g_buffs_replace 2 "If enabled, players may replace their buffs by picking up a new one. If >1, only replace if the player if holding the use/drop flag key"
 
 g_swap_teams 0
 

--- a/modfiles/rm-custom/fastaw/weapons.cfg
+++ b/modfiles/rm-custom/fastaw/weapons.cfg
@@ -3,6 +3,8 @@ g_shootfromclient 1 //reset to default
 g_ballistics_constantdamage 0 //in RM its 1
 g_ballistics_gothroughsolid 1 //in RM its 0
 
+g_pickup_respawntime_weapon 5
+
 //max ammo settings
 seta g_pickup_shells_max 60
 seta g_pickup_nails_max 320

--- a/modfiles/rm-custom/fastaw/weapons.cfg
+++ b/modfiles/rm-custom/fastaw/weapons.cfg
@@ -12,8 +12,6 @@ seta g_pickup_rockets_max 160
 seta g_pickup_cells_max 180
 seta g_pickup_fuel_max 190
 
-g_buffs_supply_grant_ammo 40
-
 //Xonotic Weapon Settings + My, they correct it alot of times
 //laser
 set g_balance_laser_primary_damage 25 //def 35

--- a/modfiles/rm-custom/fastaw/weapons.cfg
+++ b/modfiles/rm-custom/fastaw/weapons.cfg
@@ -39,7 +39,7 @@ set g_balance_laser_secondary_shotangle -90
 //shotgun
 set g_start_ammo_shells 25
 set g_balance_shotgun_primary_bullets 15
-set g_balance_shotgun_primary_damage 4
+set g_balance_shotgun_primary_damage 3
 set g_balance_shotgun_primary_force 24
 set g_balance_shotgun_primary_spread 0.10 //0.07 - def, - 0.15, 0.12 tested
 set g_balance_shotgun_primary_refire 0.6 //0.5
@@ -47,7 +47,7 @@ set g_balance_shotgun_primary_animtime 0.2
 set g_balance_shotgun_primary_ammo 1
 set g_balance_shotgun_secondary 1
 set g_balance_shotgun_secondary_bullets 15
-set g_balance_shotgun_secondary_damage 4
+set g_balance_shotgun_secondary_damage 3
 set g_balance_shotgun_secondary_force 24
 set g_balance_shotgun_secondary_spread 0.11 //0.1 -def, - 0.15 tested
 set g_balance_shotgun_secondary_refire 1.5 // 1.35


### PR DESCRIPTION
I'd like to propose some changes for fastaw (the Endless Fun server config). Progress so far:

## Weapons
* Respawn time reduced to **5 seconds**, down from 15 (like in quake3).
* **Shotgun** damage reduced by **25%** (3 per shell down from 4).

## Buffs
### Haste
* Now grants **15%** refire time reduction, down from 25%.

### Ignite
* Can now **stack**, so it's useful for weapons like the shotgun, machinegun, zapper, etc. The stacking mechanic is similar to Vampire.
* Fire damage factor reduced to **20%**, down from 35%.
* Burning time reduced to **4 seconds**, down from 5.

### Medic
* Passive armor regeneration disabled. I think medics have enough survivability with self-healing, lack of self-damage and pushback from splash weapons.

### Guard
* Set the target armor to **100**, down from 150.
* Set the armor regeneration rate to **0.15**, up from 0.11.
* These armor regeneration settings match those of health.

### Vampire
* Can now heal only up to **150** health.
* Heals faster, over **5 seconds** down from 7.
* Now pauses the decay for **0.5s** every tick.

## TODO (maybe)
* I still think that nadgets need to be gone (please @wW5roEvitkIo5fGTvUIC jump in and say that you completely agree with me). 

**In case removing nadgets is absolutely a no-go:**
* Adept and Wrath should be disabled, because to most players they feel like they do absolutely nothing useful. If you really like some of the adept effects, cvars could be added to make them baseline.
* Those that take damage (e.g. trap, nade, napalm) should be fixed to not die off every random explosion. Maybe they should only take direct hits?

**These things also require code changes:**
* Make Guard regeneration linear to be more consistent with the health system, and maybe make it disable the decay.
* Still not sure about this, but: turn Supply into an ammo regeneration buff. I don't think the 50% pickup bonus fits the current health system, even if it works for ammo.