### PR TITLE
Shoot own entity

### DIFF
--- a/modfiles/rm-custom/cra/weapons.cfg
+++ b/modfiles/rm-custom/cra/weapons.cfg
@@ -33,5 +33,3 @@ g_ballistics_simplehitscan 1
 g_shootfromeye 1
 
 g_balance_weaponswitchdelay 0.1
-
-sv_gameplayfix_shootownentities 1

--- a/modfiles/rocketminsta-gameplay.cfg
+++ b/modfiles/rocketminsta-gameplay.cfg
@@ -1025,8 +1025,7 @@ seta g_blast_alwaysfullforce 0 "If enabled, radius damage always kicks at full f
 seta g_blast_directhit_fulldamage 0 "If enabled, the direct hit entity is guaranteed to take 100% damage from the explosion"
 
 // sv_gameplayfix extensions
-seta sv_gameplayfix_zerohitcontents 0 "Prevents some invisible/nonsolid surfaces from blocking weapons on some broken maps. This changes most of the projectiles's hitboxes"
-seta sv_gameplayfix_shootownentities 0 "Enable a workaround to allow players to hit self-owned entities with traceline hitscan weapons"
+seta sv_gameplayfix_zerohitcontents 0 "Prevents some invisible/nonsolid surfaces from blocking weapons on some maps."
 
 // g_fire_damage - fire damage settings
 seta g_fire_damage_frequency 0.2 "Delay between fire damage ticks"

--- a/qcsrc/server/g_subs.qc
+++ b/qcsrc/server/g_subs.qc
@@ -305,23 +305,6 @@ void main (void)
 
 .entity trace_savedowner;
 
-void trace_start_for(entity o) {
-    if(!cvar("sv_gameplayfix_shootownentities"))
-        return;
-
-    entity e; for(;(e = findentity(e, owner, o));) {
-        e.trace_savedowner = o;
-        e.owner = world;
-    }
-}
-
-void trace_end_for(entity o) {
-    entity e; for(;(e = findentity(e, trace_savedowner, o));) {
-        e.trace_savedowner = world;
-        e.owner = o;
-    }
-}
-
 void traceline_skipnonsolid(vector start, vector end, float t, entity forent) {
     if (!cvar("sv_gameplayfix_zerohitcontents")) {
         traceline(start, end, t, forent);

--- a/qcsrc/server/w_common.qc
+++ b/qcsrc/server/w_common.qc
@@ -107,9 +107,9 @@ void FireRailgunBullet(vector start, vector end, float bdamage, float bforce, fl
 
     pts = Buffs_MEODP_Hitscan_Begin(self);
     
-    trace_start_for(self);
-    hitents = tracerail_antilag(self, start, end, FALSE, self);
-    trace_end_for(self);
+    entity temp = spawn();
+    hitents = tracerail_antilag(self, start, end, FALSE, temp);
+    remove(temp);
 
     endpoint = trace_endpos;
     endent = trace_ent;
@@ -539,31 +539,6 @@ void fireBallisticBullet(vector start, vector dir, float spread, float pSpeed, f
 		CSQCProjectile(proj, TRUE, PROJECTILE_BULLET_GLOWING, TRUE);
 	else
 		CSQCProjectile(proj, TRUE, PROJECTILE_BULLET, TRUE);
-}
-
-
-void fireBullet(vector start, vector dir, float spread, float damage, float force, float dtype, float tracer) {
-	vector  end;
-	//local entity e;
-
-	dir = normalize(dir + randomvec() * spread);
-	end = start + dir * MAX_SHOT_DISTANCE;
-
-    trace_start_for(self);
-	traceline_antilag(self, start, end, FALSE, self);
-    trace_end_for(self);
-
-    end = trace_endpos;
-
-	if ((trace_fraction != 1.0) && (pointcontents (trace_endpos) != CONTENT_SKY))
-	{
-		pointparticles(particleeffectnum("TE_KNIGHTSPIKE"),end,trace_plane_normal * 2500,1);
-		if (trace_ent.solid == SOLID_BSP && !(trace_dphitq3surfaceflags & Q3SURFACEFLAG_NOIMPACT))
-			Damage_DamageInfo(trace_endpos, damage, 0, 0, dir * max(1, force), dtype, self);
-		Damage (trace_ent, self, self, damage, dtype, trace_endpos, dir * force);
-		//void(float effectnum, vector org, vector vel, float howmany) pointparticles = #337; // same as in CSQC
-	}
-	trace_endpos = end;
 }
 
 

--- a/qcsrc/server/w_zapper.qc
+++ b/qcsrc/server/w_zapper.qc
@@ -123,9 +123,7 @@ void W_Zapper_Beam_Think(void) {
         end = self.origin;
     }
 
-    trace_start_for(o);
-    traceline_antilag(o, w_shotorg, end, FALSE, o);
-    trace_end_for(o);
+    traceline_antilag(o, w_shotorg, end, FALSE, self);
 
     targ = trace_ent;
     end = trace_endpos;
@@ -288,9 +286,9 @@ void W_Zapper_Attack2(void) {
     vector end = w_shotorg + w_shotdir * range;
     entity pts = Buffs_MEODP_Hitscan_Begin(self);
 
-    trace_start_for(self);
-    traceline_antilag(self, w_shotorg, end, FALSE, self);
-    trace_end_for(self);
+    entity temp = spawn();
+    traceline_antilag(self, w_shotorg, end, FALSE, temp);
+    remove(temp);
 
     targ = trace_ent;
     end = trace_endpos;


### PR DESCRIPTION
Функция trace_start_for неоптимальна. Для достижения нужного эффект достаточно давать временную или какую-нибудь нейтральную entity trace-функции.
Поскольку невозможность нанести урон своей entity это явный баг, то не думаю что переменная sv_gamefix_shootownentity вообще нужна. 
Предлагаю по этому поводу поудалять ненужное.