### PR TITLE
Fix shotgun secondary behaviour with switching

### DIFF
--- a/qcsrc/server/cl_player.qc
+++ b/qcsrc/server/cl_player.qc
@@ -1770,9 +1770,5 @@ float PlayerMayFire(entity plr) {
     if(timeoutStatus == 2) //don't allow the player to shoot while game is paused
         return FALSE;
 
-    // do not even think about shooting if switching
-    if(plr.switchweapon != plr.weapon)
-        return FALSE;
-
     return TRUE;
 }


### PR DESCRIPTION
Remove weapon switching check from PlayerMayFire because weapon_prepareattack already do it. And this check create some troubles with shotgun.