### PR TITLE
Run map startup config files only if map was changed (for use "restart"

### DIFF
--- a/qcsrc/server/autocvars.qh
+++ b/qcsrc/server/autocvars.qh
@@ -4,6 +4,7 @@ string autocvar__angles;
 float autocvar__campaign_index;
 string autocvar__campaign_name;
 string autocvar__origin;
+string autocvar__prevmap;
 string autocvar__radio_queue;
 float autocvar__radio_queue_left;
 string autocvar__sv_explosive_topic;

--- a/qcsrc/server/g_world.qc
+++ b/qcsrc/server/g_world.qc
@@ -870,8 +870,12 @@ void spawnfunc_worldspawn (void)
 	localcmd("\n_sv_hook_gamestart ", gametype_ID_to_Name(game), ";");
     localcmd("\nsv_hook_rmcustom_gamestart ", gametype_ID_to_Name(game), ";");
 
-	localcmd("exec startup_allmaps.cfg;");
-	localcmd(strcat("exec startup_map_", mapname, ".cfg;"));
+	if (mapname != CVAR(_prevmap)) {
+		cvar_set("_prevmap", mapname);
+		localcmd("exec startup_allmaps.cfg;");
+		localcmd(strcat("exec startup_map_", mapname, ".cfg;"));
+		localcmd("exec startup_allmaps_complete.cfg;");
+	}
 
 	world_initialized = 1;
     


### PR DESCRIPTION
command in config files).
Added startup_allmaps_complete.cfg for execution after map-specified
config.